### PR TITLE
fix: security updates for Next.js and transitive dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"embla-carousel-react": "^8.2.1",
 		"langchain": "^0.3.15",
 		"lucide-react": "^0.428.0",
-		"next": "15.5.11",
+		"next": "15.5.12",
 		"next-themes": "^0.3.0",
 		"openai": "^4.85.0",
 		"react": "^18",
@@ -71,7 +71,7 @@
 		"@typescript-eslint/parser": "^8.5.0",
 		"dotenv": "^16.4.5",
 		"eslint": "^8.57.0",
-		"eslint-config-next": "15.5.11",
+		"eslint-config-next": "15.5.12",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-import-resolver-typescript": "^3.6.3",
 		"eslint-plugin-check-file": "^2.8.0",
@@ -98,5 +98,14 @@
 		"tsx": "^4.19.1",
 		"typescript": "^5.5.4"
 	},
-	"packageManager": "pnpm@9.1.0+sha512.67f5879916a9293e5cf059c23853d571beaf4f753c707f40cb22bed5fb1578c6aad3b6c4107ccb3ba0b35be003eb621a16471ac836c87beb53f9d54bb4612724"
+	"packageManager": "pnpm@9.1.0+sha512.67f5879916a9293e5cf059c23853d571beaf4f753c707f40cb22bed5fb1578c6aad3b6c4107ccb3ba0b35be003eb621a16471ac836c87beb53f9d54bb4612724",
+	"pnpm": {
+		"overrides": {
+			"brace-expansion@<1.1.12": "1.1.12",
+			"diff@<4.0.4": "4.0.4",
+			"fast-xml-parser@<4.5.3": "4.5.3",
+			"undici@<6.21.1": "6.21.1",
+			"qs@<6.13.0": "6.13.0"
+		}
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@<1.1.12: 1.1.12
+  diff@<4.0.4: 4.0.4
+  fast-xml-parser@<4.5.3: 4.5.3
+  undici@<6.21.1: 6.21.1
+  qs@<6.13.0: 6.13.0
+
 importers:
 
   .:
@@ -13,7 +20,7 @@ importers:
         version: 0.0.49(zod@3.25.76)
       '@langchain/community':
         specifier: ^0.3.26
-        version: 0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)
+        version: 0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)
       '@langchain/core':
         specifier: ^0.3.80
         version: 0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
@@ -46,7 +53,7 @@ importers:
         version: 6.5.0
       '@upstash/rag-chat':
         specifier: ^2.0.3
-        version: 2.0.3(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0))(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(encoding@0.1.13)(fast-xml-parser@5.3.4)(google-auth-library@9.14.1(encoding@0.1.13))(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sswr@2.1.0(svelte@4.2.19))(svelte@4.2.19)(vue@3.4.38(typescript@5.5.4))(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)(zod@3.25.76)
+        version: 2.0.3(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0))(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(encoding@0.1.13)(fast-xml-parser@4.5.3)(google-auth-library@9.14.1(encoding@0.1.13))(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sswr@2.1.0(svelte@4.2.19))(svelte@4.2.19)(vue@3.4.38(typescript@5.5.4))(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)(zod@3.25.76)
       '@upstash/ratelimit':
         specifier: ^2.0.3
         version: 2.0.8(@upstash/redis@1.36.2)
@@ -55,10 +62,10 @@ importers:
         version: 1.36.2
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.3.1(next@15.5.11(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.3.1(next@15.5.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@15.5.11(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.19)(vue@3.4.38(typescript@5.5.4))
+        version: 1.0.12(next@15.5.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.19)(vue@3.4.38(typescript@5.5.4))
       ai:
         specifier: ^4.3.19
         version: 4.3.19(react@18.3.1)(zod@3.25.76)
@@ -76,13 +83,13 @@ importers:
         version: 8.2.1(react@18.3.1)
       langchain:
         specifier: ^0.3.15
-        version: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
+        version: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
       lucide-react:
         specifier: ^0.428.0
         version: 0.428.0(react@18.3.1)
       next:
-        specifier: 15.5.11
-        version: 15.5.11(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 15.5.12
+        version: 15.5.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -157,8 +164,8 @@ importers:
         specifier: ^8.57.0
         version: 8.57.0
       eslint-config-next:
-        specifier: 15.5.11
-        version: 15.5.11(eslint@8.57.0)(typescript@5.5.4)
+        specifier: 15.5.12
+        version: 15.5.12(eslint@8.57.0)(typescript@5.5.4)
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@8.57.0)
@@ -1441,7 +1448,7 @@ packages:
       discord.js: ^14.14.1
       duck-duck-scrape: ^2.2.5
       epub2: ^3.0.1
-      fast-xml-parser: '*'
+      fast-xml-parser: 4.5.3
       firebase-admin: ^11.9.0 || ^12.0.0 || ^13.0.0
       google-auth-library: '*'
       googleapis: '*'
@@ -1773,56 +1780,56 @@ packages:
   '@next/bundle-analyzer@14.2.10':
     resolution: {integrity: sha512-x9sMR1gHrX6zg5UapTJBjSEHmyG6GuSW1gWQXp4kJSNBQzKWFFhK4lQluNnyh0hP6j3p5Mxpq8uUOTYIgMgk3A==}
 
-  '@next/env@15.5.11':
-    resolution: {integrity: sha512-g9s5SS9gC7GJCEOR3OV3zqs7C5VddqxP9X+/6BpMbdXRkqsWfFf2CJPBZNvNEtAkKTNuRgRXAgNxSAXzfLdaTg==}
+  '@next/env@15.5.12':
+    resolution: {integrity: sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==}
 
-  '@next/eslint-plugin-next@15.5.11':
-    resolution: {integrity: sha512-tS/HYQOjIoX9ZNDQitba/baS8sTvo3ekY6Vgdx5lmhN4jov082bdApIChXr94qhMZHvEciz9DZglFFnhguQp/A==}
+  '@next/eslint-plugin-next@15.5.12':
+    resolution: {integrity: sha512-+ZRSDFTv4aC96aMb5E41rMjysx8ApkryevnvEYZvPZO52KvkqP5rNExLUXJFr9P4s0f3oqNQR6vopCZsPWKDcQ==}
 
-  '@next/swc-darwin-arm64@15.5.7':
-    resolution: {integrity: sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==}
+  '@next/swc-darwin-arm64@15.5.12':
+    resolution: {integrity: sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.7':
-    resolution: {integrity: sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==}
+  '@next/swc-darwin-x64@15.5.12':
+    resolution: {integrity: sha512-nqa9/7iQlboF1EFtNhWxQA0rQstmYRSBGxSM6g3GxvxHxcoeqVXfGNr9stJOme674m2V7r4E3+jEhhGvSQhJRA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.7':
-    resolution: {integrity: sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==}
+  '@next/swc-linux-arm64-gnu@15.5.12':
+    resolution: {integrity: sha512-dCzAjqhDHwmoB2M4eYfVKqXs99QdQxNQVpftvP1eGVppamXh/OkDAwV737Zr0KPXEqRUMN4uCjh6mjO+XtF3Mw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.5.7':
-    resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
+  '@next/swc-linux-arm64-musl@15.5.12':
+    resolution: {integrity: sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.5.7':
-    resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
+  '@next/swc-linux-x64-gnu@15.5.12':
+    resolution: {integrity: sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.5.7':
-    resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
+  '@next/swc-linux-x64-musl@15.5.12':
+    resolution: {integrity: sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.5.7':
-    resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
+  '@next/swc-win32-arm64-msvc@15.5.12':
+    resolution: {integrity: sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.7':
-    resolution: {integrity: sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==}
+  '@next/swc-win32-x64-msvc@15.5.12':
+    resolution: {integrity: sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2991,8 +2998,8 @@ packages:
   bowser@2.13.1:
     resolution: {integrity: sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -3443,8 +3450,8 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
   dingbat-to-unicode@1.0.1:
@@ -3650,8 +3657,8 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
-  eslint-config-next@15.5.11:
-    resolution: {integrity: sha512-RQNY69VUv0BzXkLEKDh/OPUzA+krFOnYRxO0JA3UsW429ovLa2nXx8kZuXCl18P27PyJBdS3qgJJkIhi9H8SuQ==}
+  eslint-config-next@15.5.12:
+    resolution: {integrity: sha512-ktW3XLfd+ztEltY5scJNjxjHwtKWk6vU2iwzZqSN09UsbBmMeE/cVlJ1yESg6Yx5LW7p/Z8WzUAgYXGLEmGIpg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
       typescript: '>=3.3.1'
@@ -3970,8 +3977,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-xml-parser@4.4.1:
-    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
+  fast-xml-parser@4.5.3:
+    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
     hasBin: true
 
   fast-xml-parser@5.3.4:
@@ -4947,7 +4954,7 @@ packages:
       d3-dsv: '*'
       epub2: '*'
       faiss-node: '*'
-      fast-xml-parser: '*'
+      fast-xml-parser: 4.5.3
       handlebars: ^4.7.8
       html-to-text: '*'
       ignore: '*'
@@ -5521,8 +5528,8 @@ packages:
       react: ^16.8 || ^17 || ^18
       react-dom: ^16.8 || ^17 || ^18
 
-  next@15.5.11:
-    resolution: {integrity: sha512-L2KPiKmqTDpRdeVDdPjhf43g2/VPe0NCNndq7OKDCgOLWtxe1kbr/zXGIZtYY7kZEAjRf7Bj/mwUFSr+tYC2Yg==}
+  next@15.5.12:
+    resolution: {integrity: sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -6027,8 +6034,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.11.2:
-    resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
+  qs@6.13.0:
+    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
   querystringify@2.2.0:
@@ -6481,8 +6488,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@1.0.5:
-    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+  strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
   strnum@2.1.2:
     resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
@@ -6767,8 +6774,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@6.19.8:
-    resolution: {integrity: sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==}
+  undici@6.21.1:
+    resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
     engines: {node: '>=18.17'}
 
   unified@11.0.5:
@@ -7212,7 +7219,7 @@ snapshots:
 
   '@anthropic-ai/sdk@0.27.3(encoding@0.1.13)':
     dependencies:
-      '@types/node': 18.19.50
+      '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -8070,7 +8077,7 @@ snapshots:
 
   '@browserbasehq/sdk@2.6.0(encoding@0.1.13)':
     dependencies:
-      '@types/node': 18.19.50
+      '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -8286,7 +8293,7 @@ snapshots:
 
   '@ibm-cloud/watsonx-ai@1.7.7':
     dependencies:
-      '@types/node': 18.19.50
+      '@types/node': 18.19.130
       extend: 3.0.2
       form-data: 4.0.5
       ibm-cloud-sdk-core: 5.4.5
@@ -8688,8 +8695,8 @@ snapshots:
   '@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.3.37)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))':
     dependencies:
       '@anthropic-ai/sdk': 0.25.2(encoding@0.1.13)
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      fast-xml-parser: 4.4.1
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      fast-xml-parser: 4.5.3
       zod: 3.25.76
       zod-to-json-schema: 3.23.2(zod@3.25.76)
     transitivePeerDependencies:
@@ -8697,7 +8704,7 @@ snapshots:
       - langchain
       - openai
 
-  ? '@langchain/community@0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)'
+  ? '@langchain/community@0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)'
   : dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76)
       '@ibm-cloud/watsonx-ai': 1.7.7
@@ -8708,7 +8715,7 @@ snapshots:
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.4.5
       js-yaml: 4.1.0
-      langchain: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
+      langchain: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
       langsmith: 0.3.87(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       math-expression-evaluator: 2.0.7
       openai: 4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)
@@ -8732,7 +8739,7 @@ snapshots:
       cohere-ai: 7.13.0(encoding@0.1.13)
       crypto-js: 4.2.0
       d3-dsv: 3.0.1
-      fast-xml-parser: 5.3.4
+      fast-xml-parser: 4.5.3
       google-auth-library: 9.14.1(encoding@0.1.13)
       html-to-text: 9.0.5
       ignore: 5.3.2
@@ -8767,18 +8774,18 @@ snapshots:
       - handlebars
       - peggy
 
-  ? '@langchain/community@0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15)(@langchain/core@0.2.32)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)'
+  ? '@langchain/community@0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15)(@langchain/core@0.2.32)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)'
   : dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76)
       '@ibm-cloud/watsonx-ai': 1.7.7
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      '@langchain/openai': 0.6.17(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
-      '@langchain/weaviate': 0.2.3(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(encoding@0.1.13)
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/openai': 0.6.17(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
+      '@langchain/weaviate': 0.2.3(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(encoding@0.1.13)
       binary-extensions: 2.3.0
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.4.5
       js-yaml: 4.1.0
-      langchain: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
+      langchain: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
       langsmith: 0.3.87(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       math-expression-evaluator: 2.0.7
       openai: 4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)
@@ -8802,7 +8809,7 @@ snapshots:
       cohere-ai: 7.13.0(encoding@0.1.13)
       crypto-js: 4.2.0
       d3-dsv: 3.0.1
-      fast-xml-parser: 5.3.4
+      fast-xml-parser: 4.5.3
       google-auth-library: 9.14.1(encoding@0.1.13)
       html-to-text: 9.0.5
       ignore: 5.3.2
@@ -8837,30 +8844,13 @@ snapshots:
       - handlebars
       - peggy
 
-  '@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))':
-    dependencies:
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
-      js-tiktoken: 1.0.14
-      langsmith: 0.1.47(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.23.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - langchain
-      - openai
-
-  ? '@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))'
+  ? '@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))'
   : dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.1.47(@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      langsmith: 0.1.47(@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8871,13 +8861,13 @@ snapshots:
       - langchain
       - openai
 
-  '@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))':
+  '@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.1.47(@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      langsmith: 0.1.47(@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8910,7 +8900,7 @@ snapshots:
 
   '@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.3.37)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))':
     dependencies:
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       '@mistralai/mistralai': 0.4.0(encoding@0.1.13)
       uuid: 10.0.0
       zod: 3.25.76
@@ -8920,9 +8910,9 @@ snapshots:
       - langchain
       - openai
 
-  '@langchain/openai@0.2.10(encoding@0.1.13)(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(ws@8.18.0)':
+  '@langchain/openai@0.2.10(encoding@0.1.13)(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(ws@8.18.0)':
     dependencies:
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       js-tiktoken: 1.0.14
       openai: 4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)
       zod: 3.25.76
@@ -8932,9 +8922,9 @@ snapshots:
       - langchain
       - ws
 
-  '@langchain/openai@0.6.17(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)':
+  '@langchain/openai@0.6.17(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)':
     dependencies:
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       js-tiktoken: 1.0.14
       openai: 5.12.2(ws@8.18.0)(zod@3.25.76)
       zod: 3.25.76
@@ -8950,33 +8940,25 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@0.0.3(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))':
-    dependencies:
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      js-tiktoken: 1.0.14
-    transitivePeerDependencies:
-      - langchain
-      - openai
-
-  ? '@langchain/textsplitters@0.0.3(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))'
+  ? '@langchain/textsplitters@0.0.3(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))'
   : dependencies:
-      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       js-tiktoken: 1.0.14
     transitivePeerDependencies:
       - langchain
       - openai
 
-  '@langchain/textsplitters@0.0.3(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))':
+  '@langchain/textsplitters@0.0.3(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))':
     dependencies:
-      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       js-tiktoken: 1.0.14
     transitivePeerDependencies:
       - langchain
       - openai
 
-  '@langchain/weaviate@0.2.3(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(encoding@0.1.13)':
+  '@langchain/weaviate@0.2.3(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(encoding@0.1.13)':
     dependencies:
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       uuid: 10.0.0
       weaviate-client: 3.11.0(encoding@0.1.13)
     transitivePeerDependencies:
@@ -9003,34 +8985,34 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@15.5.11': {}
+  '@next/env@15.5.12': {}
 
-  '@next/eslint-plugin-next@15.5.11':
+  '@next/eslint-plugin-next@15.5.12':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.5.7':
+  '@next/swc-darwin-arm64@15.5.12':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.7':
+  '@next/swc-darwin-x64@15.5.12':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.7':
+  '@next/swc-linux-arm64-gnu@15.5.12':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.7':
+  '@next/swc-linux-arm64-musl@15.5.12':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.7':
+  '@next/swc-linux-x64-gnu@15.5.12':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.7':
+  '@next/swc-linux-x64-musl@15.5.12':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.7':
+  '@next/swc-win32-arm64-msvc@15.5.12':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.7':
+  '@next/swc-win32-x64-msvc@15.5.12':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -10027,12 +10009,12 @@ snapshots:
     dependencies:
       '@upstash/redis': 1.36.2
 
-  ? '@upstash/rag-chat@2.0.3(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0))(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(encoding@0.1.13)(fast-xml-parser@5.3.4)(google-auth-library@9.14.1(encoding@0.1.13))(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sswr@2.1.0(svelte@4.2.19))(svelte@4.2.19)(vue@3.4.38(typescript@5.5.4))(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)(zod@3.25.76)'
+  ? '@upstash/rag-chat@2.0.3(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0))(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(encoding@0.1.13)(fast-xml-parser@4.5.3)(google-auth-library@9.14.1(encoding@0.1.13))(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sswr@2.1.0(svelte@4.2.19))(svelte@4.2.19)(vue@3.4.38(typescript@5.5.4))(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)(zod@3.25.76)'
   : dependencies:
       '@ai-sdk/openai': 0.0.44(zod@3.25.76)
       '@langchain/anthropic': 0.2.15(encoding@0.1.13)(langchain@0.3.37)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      '@langchain/community': 0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15)(@langchain/core@0.2.32)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/community': 0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15)(@langchain/core@0.2.32)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       '@langchain/mistralai': 0.0.28(encoding@0.1.13)(langchain@0.3.37)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
       '@upstash/ratelimit': 2.0.8(@upstash/redis@1.36.2)
@@ -10042,8 +10024,8 @@ snapshots:
       cheerio: 1.0.0
       d3-dsv: 3.0.1
       html-to-text: 9.0.5
-      langchain: 0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0)
-      langsmith: 0.1.47(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      langchain: 0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0)
+      langsmith: 0.1.47(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       nanoid: 5.0.7
       pdf-parse: 1.1.1
       react: 18.3.1
@@ -10211,16 +10193,16 @@ snapshots:
 
   '@upstash/vector@1.1.5': {}
 
-  '@vercel/analytics@1.3.1(next@15.5.11(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/analytics@1.3.1(next@15.5.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 15.5.11(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
-  '@vercel/speed-insights@1.0.12(next@15.5.11(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.19)(vue@3.4.38(typescript@5.5.4))':
+  '@vercel/speed-insights@1.0.12(next@15.5.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.19)(vue@3.4.38(typescript@5.5.4))':
     optionalDependencies:
-      next: 15.5.11(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       svelte: 4.2.19
       vue: 3.4.38(typescript@5.5.4)
@@ -10509,7 +10491,7 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-abstract: 1.24.1
-      es-shim-unscopables: 1.0.2
+      es-shim-unscopables: 1.1.0
 
   array.prototype.flatmap@1.3.2:
     dependencies:
@@ -10523,7 +10505,7 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-abstract: 1.24.1
-      es-shim-unscopables: 1.0.2
+      es-shim-unscopables: 1.1.0
 
   array.prototype.tosorted@1.1.4:
     dependencies:
@@ -10658,7 +10640,7 @@ snapshots:
   bowser@2.13.1:
     optional: true
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -10779,7 +10761,7 @@ snapshots:
       parse5: 7.1.2
       parse5-htmlparser2-tree-adapter: 7.0.0
       parse5-parser-stream: 7.1.2
-      undici: 6.19.8
+      undici: 6.21.1
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -10857,7 +10839,7 @@ snapshots:
       formdata-node: 6.0.3
       js-base64: 3.7.2
       node-fetch: 2.7.0(encoding@0.1.13)
-      qs: 6.11.2
+      qs: 6.13.0
       readable-stream: 4.7.0
       url-join: 4.0.1
     transitivePeerDependencies:
@@ -11139,7 +11121,7 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2: {}
+  diff@4.0.4: {}
 
   dingbat-to-unicode@1.0.1:
     optional: true
@@ -11453,8 +11435,8 @@ snapshots:
   es-to-primitive@1.3.0:
     dependencies:
       is-callable: 1.2.7
-      is-date-object: 1.0.5
-      is-symbol: 1.0.4
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   esbuild@0.23.1:
     optionalDependencies:
@@ -11499,9 +11481,9 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@15.5.11(eslint@8.57.0)(typescript@5.5.4):
+  eslint-config-next@15.5.12(eslint@8.57.0)(typescript@5.5.4):
     dependencies:
-      '@next/eslint-plugin-next': 15.5.11
+      '@next/eslint-plugin-next': 15.5.12
       '@rushstack/eslint-patch': 1.10.4
       '@typescript-eslint/eslint-plugin': 8.5.0(@typescript-eslint/parser@8.5.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
       '@typescript-eslint/parser': 8.5.0(eslint@8.57.0)(typescript@5.5.4)
@@ -11745,7 +11727,7 @@ snapshots:
 
   eslint-plugin-react@7.37.5(eslint@8.57.0):
     dependencies:
-      array-includes: 3.1.8
+      array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.3
       array.prototype.tosorted: 1.1.4
@@ -11948,9 +11930,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-parser@4.4.1:
+  fast-xml-parser@4.5.3:
     dependencies:
-      strnum: 1.0.5
+      strnum: 1.1.2
 
   fast-xml-parser@5.3.4:
     dependencies:
@@ -13222,16 +13204,16 @@ snapshots:
   kuler@2.0.0:
     optional: true
 
-  langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0):
+  langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0):
     dependencies:
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      '@langchain/openai': 0.2.10(encoding@0.1.13)(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(ws@8.18.0)
-      '@langchain/textsplitters': 0.0.3(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/openai': 0.2.10(encoding@0.1.13)(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(ws@8.18.0)
+      '@langchain/textsplitters': 0.0.3(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       binary-extensions: 2.3.0
       js-tiktoken: 1.0.14
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
-      langsmith: 0.1.47(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      langsmith: 0.1.47(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 10.0.0
@@ -13242,7 +13224,7 @@ snapshots:
       '@aws-sdk/credential-provider-node': 3.972.4
       '@browserbasehq/sdk': 2.6.0(encoding@0.1.13)
       '@langchain/anthropic': 0.2.15(encoding@0.1.13)(langchain@0.3.37)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      '@langchain/community': 0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15)(@langchain/core@0.2.32)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)
+      '@langchain/community': 0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.4.5)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(zod@3.25.76))(@datastax/astra-db-ts@1.4.1)(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.2.15)(@langchain/core@0.2.32)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@pinecone-database/pinecone@3.0.3)(@smithy/util-utf8@2.3.0)(@upstash/ratelimit@2.0.8(@upstash/redis@1.36.2))(@upstash/redis@1.36.2)(@upstash/vector@1.1.5)(@zilliz/milvus2-sdk-node@2.4.9)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(cohere-ai@7.13.0(encoding@0.1.13))(crypto-js@4.2.0)(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(google-auth-library@9.14.1(encoding@0.1.13))(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.5)(ignore@5.3.2)(jsdom@20.0.3)(jsonwebtoken@9.0.3)(lodash@4.17.23)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(pg@8.12.0)(playwright@1.58.1)(portkey-ai@0.1.16)(weaviate-client@3.11.0(encoding@0.1.13))(ws@8.18.0)
       '@langchain/mistralai': 0.0.28(encoding@0.1.13)(langchain@0.3.37)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       '@notionhq/client': 2.2.15(encoding@0.1.13)
       '@pinecone-database/pinecone': 3.0.3
@@ -13251,7 +13233,7 @@ snapshots:
       cheerio: 1.0.0
       chromadb: 1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       d3-dsv: 3.0.1
-      fast-xml-parser: 5.3.4
+      fast-xml-parser: 4.5.3
       html-to-text: 9.0.5
       ignore: 5.3.2
       jsdom: 20.0.3
@@ -13264,11 +13246,11 @@ snapshots:
       - encoding
       - openai
 
-  ? langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
+  ? langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
   : dependencies:
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      '@langchain/openai': 0.6.17(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
-      '@langchain/textsplitters': 0.0.3(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/openai': 0.6.17(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
+      '@langchain/textsplitters': 0.0.3(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       js-tiktoken: 1.0.14
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
@@ -13291,11 +13273,11 @@ snapshots:
       - openai
       - ws
 
-  langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0):
+  langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0):
     dependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(ws@8.18.0)
-      '@langchain/textsplitters': 0.0.3(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      '@langchain/textsplitters': 0.0.3(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
       js-tiktoken: 1.0.14
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
@@ -13318,7 +13300,7 @@ snapshots:
       - openai
       - ws
 
-  ? langsmith@0.1.47(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+  ? langsmith@0.1.47(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
   : dependencies:
       '@types/uuid': 10.0.0
       commander: 10.0.1
@@ -13327,11 +13309,11 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      langchain: 0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0)
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      langchain: 0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0)
       openai: 4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)
 
-  ? langsmith@0.1.47(@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+  ? langsmith@0.1.47(@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
   : dependencies:
       '@types/uuid': 10.0.0
       commander: 10.0.1
@@ -13340,11 +13322,11 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      langchain: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      langchain: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4)(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@4.5.3)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
       openai: 4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)
 
-  ? langsmith@0.1.47(@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+  ? langsmith@0.1.47(@langchain/core@0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
   : dependencies:
       '@types/uuid': 10.0.0
       commander: 10.0.1
@@ -13353,8 +13335,8 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      '@langchain/core': 0.2.32(langchain@0.2.19(@aws-sdk/credential-provider-node@3.972.4)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@langchain/anthropic@0.2.15)(@langchain/community@0.3.59)(@langchain/mistralai@0.0.28)(@notionhq/client@2.2.15(encoding@0.1.13))(@pinecone-database/pinecone@3.0.3)(assemblyai@4.7.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(chromadb@1.8.1(cohere-ai@7.13.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(d3-dsv@3.0.1)(encoding@0.1.13)(fast-xml-parser@5.3.4)(html-to-text@9.0.5)(ignore@5.3.2)(jsdom@20.0.3)(mammoth@1.8.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(pdf-parse@1.1.1)(peggy@3.0.2)(playwright@1.58.1)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
-      langchain: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4(debug@4.4.3))(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
+      '@langchain/core': 0.2.32(langchain@0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0))(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))
+      langchain: 0.3.37(@langchain/anthropic@0.2.15(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@langchain/mistralai@0.0.28(encoding@0.1.13)(langchain@0.2.19)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.0.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76))(peggy@3.0.2)(ws@8.18.0)
       openai: 4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)
 
   langsmith@0.3.87(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.18.0)(zod@3.25.76)):
@@ -13779,7 +13761,7 @@ snapshots:
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
   minimatch@9.0.5:
     dependencies:
@@ -13820,9 +13802,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@15.5.11(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.5.12(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 15.5.11
+      '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001653
       postcss: 8.4.31
@@ -13830,14 +13812,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.25.2)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.7
-      '@next/swc-darwin-x64': 15.5.7
-      '@next/swc-linux-arm64-gnu': 15.5.7
-      '@next/swc-linux-arm64-musl': 15.5.7
-      '@next/swc-linux-x64-gnu': 15.5.7
-      '@next/swc-linux-x64-musl': 15.5.7
-      '@next/swc-win32-arm64-msvc': 15.5.7
-      '@next/swc-win32-x64-msvc': 15.5.7
+      '@next/swc-darwin-arm64': 15.5.12
+      '@next/swc-darwin-x64': 15.5.12
+      '@next/swc-linux-arm64-gnu': 15.5.12
+      '@next/swc-linux-arm64-musl': 15.5.12
+      '@next/swc-linux-x64-gnu': 15.5.12
+      '@next/swc-linux-x64-musl': 15.5.12
+      '@next/swc-win32-arm64-msvc': 15.5.12
+      '@next/swc-win32-x64-msvc': 15.5.12
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.58.1
       sharp: 0.34.5
@@ -14353,7 +14335,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.11.2:
+  qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
     optional: true
@@ -14959,7 +14941,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@1.0.5: {}
+  strnum@1.1.2: {}
 
   strnum@2.1.2:
     optional: true
@@ -15168,7 +15150,7 @@ snapshots:
       acorn-walk: 8.3.3
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
@@ -15227,7 +15209,7 @@ snapshots:
   typed-array-byte-length@1.0.3:
     dependencies:
       call-bind: 1.0.8
-      for-each: 0.3.3
+      for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
       is-typed-array: 1.1.15
@@ -15245,7 +15227,7 @@ snapshots:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.8
-      for-each: 0.3.3
+      for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
       is-typed-array: 1.1.15
@@ -15263,11 +15245,11 @@ snapshots:
   typed-array-length@1.0.7:
     dependencies:
       call-bind: 1.0.8
-      for-each: 0.3.3
+      for-each: 0.3.5
       gopd: 1.2.0
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.0.0
-      reflect.getprototypeof: 1.0.6
+      reflect.getprototypeof: 1.0.10
 
   typed-emitter@2.1.0:
     optionalDependencies:
@@ -15301,7 +15283,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@6.19.8: {}
+  undici@6.21.1: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Summary
- Update Next.js from 15.5.11 to 15.5.12 (security backport with PPR vulnerability fix)
- Update eslint-config-next to 15.5.12
- Add pnpm overrides to fix vulnerable transitive dependencies:
  - `brace-expansion`: 1.1.12 (fixes ReDoS vulnerability)
  - `diff`: 4.0.4 (fixes DoS vulnerability)  
  - `fast-xml-parser`: 4.5.3 (fixes RangeError DoS)
  - `undici`: 6.21.1 (fixes unbounded decompression chain)
  - `qs`: 6.13.0 (fixes memory exhaustion DoS)

This addresses the critical and high severity security alerts from Dependabot without introducing breaking changes from AI SDK v5 or Next.js 16.

## Test plan
- [x] Linter passes
- [x] All Jest tests pass
- [x] Build succeeds
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)